### PR TITLE
Raise reviewer.chat validation error outside of server 

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -48,7 +48,6 @@ review <- function(file_path, model = NULL, max_pending = NULL) {
     collapse = "\n"
   )
 
-  # Validate chat configuration early (before launching Shiny)
   client <- new_reviewer_chat(model, system_prompt)
   client$register_tool(tool_propose_edit(max_pending = max_pending))
 

--- a/R/app.R
+++ b/R/app.R
@@ -48,6 +48,10 @@ review <- function(file_path, model = NULL, max_pending = NULL) {
     collapse = "\n"
   )
 
+  # Validate chat configuration early (before launching Shiny)
+  client <- new_reviewer_chat(model, system_prompt)
+  client$register_tool(tool_propose_edit(max_pending = max_pending))
+
 
   ui <- function(req) {
     bslib::page_fillable(
@@ -94,9 +98,6 @@ review <- function(file_path, model = NULL, max_pending = NULL) {
 
   server <- function(input, output, session) {
     shiny::addResourcePath("reviewer", system.file("www", package = "reviewer"))
-
-    client <- new_reviewer_chat(model, system_prompt)
-    client$register_tool(tool_propose_edit(max_pending = max_pending))
 
     reset_reviews()
 


### PR DESCRIPTION
Previously, this error was raised in the server rather than outside of it, resulting in a bunch of extra context being appended to the error:

```
 review("example.R")

Listening on http://127.0.0.1:7550

Warning: Error in server: ! reviewer requires configuring an ellmer Chat with the `reviewer.chat` option or

  the `model` argument.

ℹ Set e.g. `options(reviewer.chat = ellmer::chat_claude("claude-sonnet-4-5-20250514"))`

  in your \~/.Rprofile and restart R.

  47: <Anonymous>

  46: signalCondition

  45: signal\_abort

  44: rlang::abort

  43: cli::cli\_abort

  42: new\_reviewer\_chat [/Users/simoncouch/Documents/rrr/reviewer/R/aaa.R#13]

  41: server [/Users/simoncouch/Documents/rrr/reviewer/R/app.R#100]

   2: shiny::runApp

   1: review [/Users/simoncouch/Documents/rrr/reviewer/R/app.R#294]

Error in server(...) : 

  ! reviewer requires configuring an ellmer Chat with the `reviewer.chat` option or

  the `model` argument.

ℹ Set e.g. `options(reviewer.chat = ellmer::chat_claude("claude-sonnet-4-5-20250514"))`

  in your \~/.Rprofile and restart R.
```

We now raise it earlier.